### PR TITLE
feat(linear-regression): add fast stub model, improved state handling, tests, and docs

### DIFF
--- a/.codacy/codacy.yaml
+++ b/.codacy/codacy.yaml
@@ -1,0 +1,15 @@
+runtimes:
+    - dart@3.7.2
+    - go@1.22.3
+    - java@17.0.10
+    - node@22.2.0
+    - python@3.11.11
+tools:
+    - dartanalyzer@3.7.2
+    - eslint@8.57.0
+    - lizard@1.17.31
+    - pmd@7.11.0
+    - pylint@3.3.6
+    - revive@1.7.0
+    - semgrep@1.78.0
+    - trivy@0.66.0

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,55 @@
+# Virtual environments
 .venv
+venv/
+env/
+ENV/
+
+# Python cache
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+
+# IDEs
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+.eggs/
+
+# Logs
+*.log
+
+# Database
+*.db
+*.sqlite3
+
+# ML Models (if saved as files)
+*.pkl
+*.joblib
+*.h5
+*.pt
+*.pth
+
+#Ignore vscode AI rules
+.github/instructions/codacy.instructions.md

--- a/README.md
+++ b/README.md
@@ -1,13 +1,195 @@
 # 🤖 ML Model Simulator
 
-A Streamlit-based platform to explore basic ML models interactively.
+A Streamlit-based platform to explore basic ML models interactively, now with REST API support!
 
 ## Features
 - 📈 Linear Regression with adjustable parameters
 - 📊 Logistic Regression with decision boundary visualization
+- 🔌 REST API for external model access
 - ✅ Easy to extend with new models
 
 ## How to Run
+
+### Web Interface (Streamlit)
 ```bash
 pip install -r requirements.txt
 streamlit run app.py
+```
+
+### REST API Server
+```bash
+pip install -r requirements.txt
+python api.py
+```
+Or using uvicorn directly:
+```bash
+uvicorn api:app --host 0.0.0.0 --port 8000 --reload
+```
+
+The API will be available at `http://localhost:8000`
+- Interactive API documentation: `http://localhost:8000/docs`
+- Alternative API docs: `http://localhost:8000/redoc`
+
+## API Usage
+
+### Startup Note
+The first request (or server start) can take ~40 seconds on some machines due to the initial `scikit-learn` import. Subsequent requests are fast. If you need faster cold starts, consider:
+- Pre-importing `sklearn` in a separate warm-up script before starting Uvicorn
+- Using a smaller environment or pruning unused sklearn modules
+- Building a Docker image and letting the import happen at container build time
+
+### Error Responses
+Common error cases the API will return with JSON `detail` field:
+- 400: Mismatched lengths between `X` and `y` during training
+- 400: Calling predict before training the model
+- 400: Malformed JSON (e.g., wrong shapes that cannot be converted to arrays)
+- 500: Unexpected server errors during training or prediction
+
+Example (predict before training):
+```bash
+curl -s -X POST "http://localhost:8000/api/v1/linear-regression/predict" \
+  -H "Content-Type: application/json" \
+  -d '{"features": [[1.0], [2.0]]}' | jq
+```
+Response:
+```json
+{
+  "detail": "Model not trained. Please train the model first using /api/v1/linear-regression/train endpoint"
+}
+```
+
+### Health Check
+```bash
+curl http://localhost:8000/health
+```
+
+### List Available Models
+```bash
+curl http://localhost:8000/api/v1/models
+```
+
+### Linear Regression - Train Model
+```bash
+curl -X POST "http://localhost:8000/api/v1/linear-regression/train" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "X": [[1.0], [2.0], [3.0], [4.0], [5.0]],
+    "y": [2.0, 4.0, 5.0, 4.0, 5.0]
+  }'
+```
+
+### Linear Regression - Make Predictions
+```bash
+curl -X POST "http://localhost:8000/api/v1/linear-regression/predict" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "features": [[1.0], [2.0], [3.0]]
+  }'
+```
+
+### Linear Regression - Train and Predict (One-Step)
+```bash
+curl -X POST "http://localhost:8000/api/v1/linear-regression/train-and-predict" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "X": [[1.0], [2.0], [3.0], [4.0], [5.0]],
+    "y": [2.0, 4.0, 5.0, 4.0, 5.0]
+  }'
+```
+
+### Python Example
+```python
+import requests
+
+# Train the model
+train_data = {
+    "X": [[1.0], [2.0], [3.0], [4.0], [5.0]],
+    "y": [2.0, 4.0, 5.0, 4.0, 5.0]
+}
+response = requests.post(
+    "http://localhost:8000/api/v1/linear-regression/train",
+    json=train_data
+)
+print(response.json())
+
+# Make predictions
+predict_data = {
+    "features": [[6.0], [7.0], [8.0]]
+}
+response = requests.post(
+    "http://localhost:8000/api/v1/linear-regression/predict",
+    json=predict_data
+)
+print(response.json())
+```
+
+### JavaScript Example
+```javascript
+// Train the model
+const trainData = {
+    X: [[1.0], [2.0], [3.0], [4.0], [5.0]],
+    y: [2.0, 4.0, 5.0, 4.0, 5.0]
+};
+
+fetch('http://localhost:8000/api/v1/linear-regression/train', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(trainData)
+})
+.then(response => response.json())
+.then(data => console.log(data));
+
+// Make predictions
+const predictData = {
+    features: [[6.0], [7.0], [8.0]]
+};
+
+fetch('http://localhost:8000/api/v1/linear-regression/predict', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(predictData)
+})
+.then(response => response.json())
+.then(data => console.log(data));
+```
+
+## API Endpoints
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/` | API root and health status |
+| GET | `/health` | Health check |
+| GET | `/api/v1/models` | List all available models |
+| POST | `/api/v1/linear-regression/train` | Train Linear Regression model |
+| POST | `/api/v1/linear-regression/predict` | Make predictions with trained model |
+| POST | `/api/v1/linear-regression/train-and-predict` | Train and predict in one call |
+
+## Testing
+
+Minimal automated tests are included for core functionality plus error cases.
+
+Run tests:
+```bash
+python -m pip install -r requirements.txt
+python tests/test_api.py
+```
+Expected output includes passing tests for:
+- Health endpoint
+- Train then predict flow
+- Combined train-and-predict
+- Predict before training (error 400)
+- Mismatched `X` and `y` lengths (error 400)
+
+If you want to run them with `pytest`, you can install pytest and run:
+```bash
+pip install pytest
+pytest -q
+```
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.
+
+## License
+
+See [LICENSE](LICENSE) for license information.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,23 @@
-# 🤖 ML Model Simulator
+# � ML Simulator
 
-A Streamlit-based platform to explore basic ML models interactively, now with REST API support!
+ML Simulator is an interactive web application built with **Streamlit** that allows users to **visualize, train, and understand popular Machine Learning algorithms** in a simple and intuitive way. It also provides a **REST API** for external model access.
 
 ## Features
-- 📈 Linear Regression with adjustable parameters
-- 📊 Logistic Regression with decision boundary visualization
-- 🔌 REST API for external model access
-- ✅ Easy to extend with new models
+-Interactive simulation of ML algorithms  
+-Adjustable hyperparameters for each model  
+-Visualization of predictions and decision boundaries  
+-Evaluation metrics including Confusion Matrix and ROC Curve  
+-REST API for external model access  
+-Clean and modular code structure  
+-Easy to extend with new models
+
+## Supported Algorithms
+| Category       | Algorithms                                                    |
+| -------------- | -------------------------------------------------------------- |
+| Classification | Logistic Regression, Decision Tree, Random Forest, K-Nearest Neighbors (KNN) |
+| Regression     | Linear Regression, Polynomial Regression                     |
+| Clustering     | K-Means                                                       |
+| Metrics        | Confusion Matrix, ROC Curve, Accuracy, AUC                    |
 
 ## How to Run
 

--- a/api.py
+++ b/api.py
@@ -1,0 +1,303 @@
+"""
+FastAPI application for ML Model Simulator
+Provides REST API endpoints to access ML models externally
+"""
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+import numpy as np
+import os
+from api_models import (
+    LinearRegressionRequest,
+    LinearRegressionTrainRequest,
+    PredictionResponse,
+    TrainResponse,
+    HealthResponse
+)
+
+# Initialize FastAPI app
+app = FastAPI(
+    title="ML Model Simulator API",
+    description="API to access ML models externally. Send JSON input and receive prediction output.",
+    version="1.0.0"
+)
+
+# Constants
+MODEL_LINEAR_REGRESSION = "Linear Regression"
+
+"""Security note: CORS restricted to local development origins.
+Adjust ALLOWED_ORIGINS when deploying to another host/domain."""
+ALLOWED_ORIGINS = [
+    "http://localhost",
+    "http://127.0.0.1",
+    "http://localhost:8000",
+    "http://127.0.0.1:8000",
+    "http://localhost:8501",  # Streamlit default
+    "http://127.0.0.1:8501",
+]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=ALLOWED_ORIGINS,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+def _init_state(application: FastAPI):
+    """Initialize shared application state.
+
+    Attributes added:
+        linear_regression_model: Trained LinearRegression instance or None
+    """
+    application.state.linear_regression_model = None
+
+
+@app.on_event("startup")
+async def startup_event():  # pragma: no cover - simple log
+    _init_state(app)
+    # Simple visibility log
+    print("[startup] ML Model Simulator API started. Docs at /docs")
+
+
+@app.get("/", response_model=HealthResponse)
+async def root():
+    """Root endpoint - API health check"""
+    return HealthResponse(
+        status="online",
+        message="ML Model Simulator API is running. Visit /docs for API documentation."
+    )
+
+
+@app.get("/health", response_model=HealthResponse)
+async def health_check():
+    """Health check endpoint"""
+    return HealthResponse(
+        status="healthy",
+        message="API is operational"
+    )
+
+
+@app.post("/api/v1/linear-regression/train", response_model=TrainResponse)
+async def train_linear_regression(request: LinearRegressionTrainRequest):
+    """
+    Train a Linear Regression model
+    
+    Args:
+        request: Training data with features (X) and labels (y)
+    
+    Returns:
+        Training confirmation with model coefficients and intercept
+    
+    Example:
+        ```json
+        {
+            "X": [[1.0], [2.0], [3.0], [4.0], [5.0]],
+            "y": [2.0, 4.0, 5.0, 4.0, 5.0]
+        }
+        ```
+    """
+    try:
+        # Convert input to numpy arrays
+        X = np.array(request.X)
+        y = np.array(request.y)
+
+        # Validate dimensions
+        if len(X) != len(y):
+            raise HTTPException(
+                status_code=400,
+                detail=f"X and y must have same length. Got X: {len(X)}, y: {len(y)}"
+            )
+
+        # Decide whether to use stub model to avoid heavy sklearn import (set USE_STUB_LINEAR=1 for tests)
+        use_stub = os.getenv("USE_STUB_LINEAR") == "1"
+
+        if use_stub:
+            class _StubLinearRegression:
+                def __init__(self):
+                    self.coef_ = np.zeros(X.shape[1]) if X.ndim > 1 else np.array([0.0])
+                    self.intercept_ = 0.0
+
+                def fit(self, x_fit, y_fit):
+                    # Provide a simple deterministic coefficient for single-feature data
+                    if x_fit.ndim == 2 and x_fit.shape[1] == 1:
+                        x = x_fit[:, 0]
+                        yloc = y_fit
+                        denom = (x - x.mean()).sum() or 1.0
+                        slope = ((x - x.mean()) * (yloc - yloc.mean())).sum() / denom
+                        self.coef_ = np.array([slope])
+                        self.intercept_ = float(yloc.mean() - slope * x.mean())
+                    return self
+
+                def predict(self, x_in):
+                    x_in = np.array(x_in)
+                    if x_in.ndim == 2:
+                        return x_in[:, 0] * self.coef_[0] + self.intercept_
+                    return x_in * self.coef_[0] + self.intercept_
+
+            model = _StubLinearRegression()
+        else:
+            # Lazy import to speed API startup (heavy sklearn import deferred until training actually requested)
+            from sklearn.linear_model import LinearRegression  # type: ignore
+            model = LinearRegression()
+
+        model.fit(X, y)
+        app.state.linear_regression_model = model
+
+        return TrainResponse(
+            message="Linear Regression model trained successfully",
+            model_type=MODEL_LINEAR_REGRESSION,
+            coefficients=model.coef_.tolist(),
+            intercept=float(model.intercept_)
+    )
+    except HTTPException:
+        # Re-raise validation HTTPExceptions directly (e.g., length mismatch)
+        raise
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=f"Invalid input data: {str(e)}")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Training failed: {str(e)}")
+
+
+@app.post("/api/v1/linear-regression/predict", response_model=PredictionResponse)
+async def predict_linear_regression(request: LinearRegressionRequest):
+    """
+    Make predictions using trained Linear Regression model
+    
+    Args:
+        request: Features for prediction
+    
+    Returns:
+        Predictions for input features
+    
+    Example:
+        ```json
+        {
+            "features": [[1.0], [2.0], [3.0]]
+        }
+        ```
+    """
+    model = getattr(app.state, "linear_regression_model", None)
+    # Ensure model is trained
+    if model is None:
+        raise HTTPException(
+            status_code=400,
+            detail="Model not trained. Please train the model first using /api/v1/linear-regression/train endpoint",
+        )
+
+    try:
+        X = np.array(request.features)
+        predictions = model.predict(X)
+        return PredictionResponse(
+            predictions=predictions.tolist(),
+            model_type=MODEL_LINEAR_REGRESSION,
+        )
+    except ValueError as e:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid input data: {str(e)}",
+        )
+    except Exception as e:  # pragma: no cover - unexpected path
+        raise HTTPException(
+            status_code=500,
+            detail=f"Prediction failed: {str(e)}",
+        )
+
+
+@app.post("/api/v1/linear-regression/train-and-predict", response_model=PredictionResponse)
+async def train_and_predict_linear_regression(
+    train_request: LinearRegressionTrainRequest,
+):
+    """
+    Train model and make predictions in one call
+    
+    Args:
+        train_request: Training data (X, y) - predictions will be made on X
+    
+    Returns:
+        Predictions for training features
+    
+    Example:
+        ```json
+        {
+            "X": [[1.0], [2.0], [3.0], [4.0], [5.0]],
+            "y": [2.0, 4.0, 5.0, 4.0, 5.0]
+        }
+        ```
+    """
+    try:
+        X = np.array(train_request.X)
+        y = np.array(train_request.y)
+        if len(X) != len(y):
+            raise HTTPException(
+                status_code=400,
+                detail=f"X and y must have same length. Got X: {len(X)}, y: {len(y)}",
+            )
+        use_stub = os.getenv("USE_STUB_LINEAR") == "1"
+        if use_stub:
+            class _StubLinearRegression:
+                def __init__(self):
+                    self.coef_ = np.zeros(X.shape[1]) if X.ndim > 1 else np.array([0.0])
+                    self.intercept_ = 0.0
+
+                def fit(self, x_fit, y_fit):
+                    if x_fit.ndim == 2 and x_fit.shape[1] == 1:
+                        x = x_fit[:, 0]
+                        yloc = y_fit
+                        denom = (x - x.mean()).sum() or 1.0
+                        slope = ((x - x.mean()) * (yloc - yloc.mean())).sum() / denom
+                        self.coef_ = np.array([slope])
+                        self.intercept_ = float(yloc.mean() - slope * x.mean())
+                    return self
+
+                def predict(self, x_in):
+                    x_in = np.array(x_in)
+                    if x_in.ndim == 2:
+                        return x_in[:, 0] * self.coef_[0] + self.intercept_
+                    return x_in * self.coef_[0] + self.intercept_
+
+            model = _StubLinearRegression()
+        else:
+            from sklearn.linear_model import LinearRegression  # type: ignore
+            model = LinearRegression()
+        model.fit(X, y)
+        predictions = model.predict(X)
+        return PredictionResponse(
+            predictions=predictions.tolist(),
+            model_type=MODEL_LINEAR_REGRESSION,
+        )
+    except ValueError as e:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid input data: {str(e)}",
+        )
+    except Exception as e:  # pragma: no cover - unexpected path
+        raise HTTPException(
+            status_code=500,
+            detail=f"Operation failed: {str(e)}",
+        )
+
+
+@app.get("/api/v1/models")
+async def list_models():
+    """
+    List all available models and their status
+    
+    Returns:
+        Dictionary of available models and their training status
+    """
+    model = getattr(app.state, "linear_regression_model", None)
+    return {
+        "models": [
+            {
+                "name": MODEL_LINEAR_REGRESSION,
+                "endpoint": "/api/v1/linear-regression",
+                "trained": model is not None,
+                "methods": ["train", "predict", "train-and-predict"],
+            }
+        ]
+    }
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/api_models.py
+++ b/api_models.py
@@ -1,0 +1,54 @@
+"""
+Pydantic models for API request and response schemas
+"""
+from pydantic import BaseModel, Field
+from typing import List, Optional
+
+
+class LinearRegressionRequest(BaseModel):
+    """Request model for Linear Regression prediction"""
+    features: List[List[float]] = Field(
+        ..., 
+        description="List of feature vectors for prediction",
+        example=[[1.0], [2.0], [3.0]]
+    )
+
+
+class LinearRegressionTrainRequest(BaseModel):
+    """Request model for training Linear Regression model"""
+    X: List[List[float]] = Field(
+        ..., 
+        description="Training features",
+        example=[[1.0], [2.0], [3.0], [4.0], [5.0]]
+    )
+    y: List[float] = Field(
+        ..., 
+        description="Training labels",
+        example=[2.0, 4.0, 5.0, 4.0, 5.0]
+    )
+
+
+class PredictionResponse(BaseModel):
+    """Response model for predictions"""
+    predictions: List[float] = Field(
+        ..., 
+        description="Model predictions"
+    )
+    model_type: str = Field(
+        ..., 
+        description="Type of model used"
+    )
+
+
+class TrainResponse(BaseModel):
+    """Response model for training endpoints"""
+    message: str
+    model_type: str
+    coefficients: Optional[List[float]] = None
+    intercept: Optional[float] = None
+
+
+class HealthResponse(BaseModel):
+    """Response model for health check"""
+    status: str
+    message: str

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,8 @@ scikit-learn
 matplotlib
 seaborn
 numpy
+fastapi
+uvicorn[standard]
+pydantic
+requests
+httpx

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,76 @@
+"""Minimal automated tests for ML Simulator API using TestClient."""
+from fastapi.testclient import TestClient
+from api import app, _init_state  # type: ignore
+
+client = TestClient(app)
+
+
+def test_health():
+    r = client.get("/health")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["status"] in {"healthy", "online"}
+
+
+def test_train_and_predict_flow():
+    # Train
+    train_payload = {"X": [[1], [2], [3], [4], [5]], "y": [2, 4, 5, 4, 5]}
+    r = client.post("/api/v1/linear-regression/train", json=train_payload)
+    assert r.status_code == 200, r.text
+    train_data = r.json()
+    assert train_data["model_type"] == "Linear Regression"
+    # Predict
+    predict_payload = {"features": [[6], [7]]}
+    r = client.post("/api/v1/linear-regression/predict", json=predict_payload)
+    assert r.status_code == 200, r.text
+    pred = r.json()
+    assert "predictions" in pred and len(pred["predictions"]) == 2
+
+
+def test_train_and_predict_single_call():
+    payload = {"X": [[1], [2], [3]], "y": [2, 4, 5]}
+    r = client.post("/api/v1/linear-regression/train-and-predict", json=payload)
+    assert r.status_code == 200
+    data = r.json()
+    assert len(data["predictions"]) == 3
+
+
+def test_predict_before_training():
+    """Calling predict without prior training should return 400."""
+    _init_state(app)  # reset model state explicitly
+    fresh_client = TestClient(app)
+    r = fresh_client.post(
+        "/api/v1/linear-regression/predict",
+        json={"features": [[1], [2]]},
+    )
+    assert r.status_code == 400, r.text
+    assert "Model not trained" in r.text
+
+
+def test_train_mismatched_lengths():
+    """Training with mismatched X and y lengths should return 400."""
+    _init_state(app)  # ensure clean state
+    payload = {"X": [[1], [2], [3]], "y": [10, 20]}  # mismatch
+    r = client.post("/api/v1/linear-regression/train", json=payload)
+    assert r.status_code == 400, r.text
+    assert "must have same length" in r.text
+
+
+if __name__ == "__main__":  # Simple ad-hoc runner
+    failures = 0
+    for fn in [
+        test_health,
+        test_train_and_predict_flow,
+        test_train_and_predict_single_call,
+        test_predict_before_training,
+        test_train_mismatched_lengths,
+    ]:
+        try:
+            fn()
+            print(f"[PASS] {fn.__name__}")
+        except AssertionError as e:
+            failures += 1
+            print(f"[FAIL] {fn.__name__}: {e}")
+    if failures:
+        raise SystemExit(1)
+    print("All tests passed.")


### PR DESCRIPTION
# 📥 Pull Request for Hacktoberfest 2025

## Description
Please include a summary of the change and which issue is fixed.
Introduces a fast test/stub pathway for the linear regression workflow, improves application state management, expands test coverage (including negative/error cases), and updates documentation for clarity on startup latency and usage.

Key Changes

Refactor: Replace module-level global model with app.state storage
Performance: Add USE_STUB_LINEAR env flag and lightweight in-memory regression stub (no sklearn import in fast mode)
Lazy Import: Only import scikit-learn when real model needed
Error Handling: Preserve 400 responses (re-raise HTTPException) and add length validation before training
Tests: Added 5 total tests (health, train+predict, train-and-predict, predict-before-training, mismatched-length) with explicit state reset helper
Docs: README updated (endpoints, error responses, startup note, testing instructions)
Quality: Added Codacy config; all tests green locally in both stub and real modes
DX: Faster CI/local cycles using stub path

Fixes #13 

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist
- [x] My code follows the project style guidelines
- [x] I have tested my changes
- [x] I have updated documentation if needed
- [x] This PR is ready for review 🚀
