### PR TITLE
Add Random Forest classifier simulator

### DIFF
--- a/models/random_forest.py
+++ b/models/random_forest.py
@@ -1,0 +1,63 @@
+"""
+Random Forest utilities.
+"""
+
+from typing import Dict, Optional, Tuple
+
+import numpy as np
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.metrics import (
+    accuracy_score,
+    precision_recall_fscore_support,
+    roc_auc_score,
+)
+
+
+def train_random_forest(
+    X,
+    y,
+    n_estimators: int = 200,
+    max_depth: Optional[int] = None,
+    criterion: str = "gini",
+    random_state: Optional[int] = 42,
+) -> RandomForestClassifier:
+    """
+    Fit a RandomForestClassifier with the provided data and hyperparameters.
+    """
+    model = RandomForestClassifier(
+        n_estimators=n_estimators,
+        max_depth=max_depth,
+        criterion=criterion,
+        random_state=random_state,
+    )
+    model.fit(X, y)
+    return model
+
+
+def evaluate_random_forest(
+    model: RandomForestClassifier, X, y_true
+) -> Tuple[np.ndarray, Optional[np.ndarray], Dict[str, float]]:
+    """
+    Compute predictions and performance metrics for a trained model.
+    """
+    y_pred = model.predict(X)
+    unique_classes = np.unique(y_true)
+    average = "binary" if len(unique_classes) == 2 else "macro"
+
+    precision, recall, f1, _ = precision_recall_fscore_support(
+        y_true, y_pred, average=average, zero_division=0
+    )
+
+    metrics: Dict[str, float] = {
+        "accuracy": accuracy_score(y_true, y_pred),
+        "precision": precision,
+        "recall": recall,
+        "f1_score": f1,
+    }
+
+    y_proba: Optional[np.ndarray] = None
+    if len(unique_classes) == 2 and hasattr(model, "predict_proba"):
+        y_proba = model.predict_proba(X)[:, 1]
+        metrics["roc_auc"] = roc_auc_score(y_true, y_proba)
+
+    return y_pred, y_proba, metrics

--- a/pages/RandomForest.py
+++ b/pages/RandomForest.py
@@ -1,0 +1,124 @@
+import pandas as pd
+import streamlit as st
+from sklearn.model_selection import train_test_split
+
+from models.random_forest import evaluate_random_forest, train_random_forest
+from utils.data_helpers import generate_sample_classification
+from utils.plot_helpers import (
+    plot_confusion_matrix,
+    plot_feature_importance,
+    plot_roc_curve,
+)
+
+st.header("🌲 Random Forest Classifier Simulator")
+
+st.write(
+    "Experiment with a Random Forest classifier by tweaking the dataset and "
+    "model hyperparameters. Evaluate performance metrics, inspect the confusion "
+    "matrix, plot the ROC curve, and explore feature importances."
+)
+
+with st.sidebar:
+    st.header("Dataset Settings")
+    n_samples = st.slider("Samples", min_value=100, max_value=1000, value=400, step=50)
+    n_features = st.slider("Features", min_value=2, max_value=15, value=6, step=1)
+    n_informative = st.slider(
+        "Informative Features",
+        min_value=1,
+        max_value=n_features,
+        value=min(4, n_features),
+        step=1,
+    )
+    max_redundant = max(n_features - n_informative, 0)
+    n_redundant = st.slider(
+        "Redundant Features",
+        min_value=0,
+        max_value=max_redundant,
+        value=min(1, max_redundant),
+        step=1,
+    )
+    class_sep = st.slider(
+        "Class Separation", min_value=0.5, max_value=3.0, value=1.2, step=0.1
+    )
+    flip_y = st.slider(
+        "Label Noise", min_value=0.0, max_value=0.3, value=0.02, step=0.01
+    )
+    test_size = st.slider(
+        "Test Split", min_value=0.1, max_value=0.5, value=0.25, step=0.05
+    )
+    random_state = st.number_input(
+        "Random Seed", min_value=0, max_value=10_000, value=42, step=1
+    )
+
+    st.header("Model Hyperparameters")
+    n_estimators = st.slider(
+        "Number of Trees", min_value=10, max_value=500, value=200, step=10
+    )
+    max_depth_choice = st.selectbox(
+        "Maximum Depth", options=["None", 3, 5, 7, 10, 15, 20], index=0
+    )
+    max_depth = None if max_depth_choice == "None" else int(max_depth_choice)
+    criterion = st.selectbox("Split Criterion", options=["gini", "entropy"], index=0)
+
+X_df, y_series = generate_sample_classification(
+    n_samples=n_samples,
+    n_features=n_features,
+    n_informative=n_informative,
+    n_redundant=n_redundant,
+    class_sep=class_sep,
+    flip_y=flip_y,
+    random_state=int(random_state),
+)
+
+st.subheader("Dataset Preview")
+st.caption("First five rows of the generated dataset.")
+st.dataframe(pd.concat([X_df, y_series], axis=1).head())
+
+X_train, X_test, y_train, y_test = train_test_split(
+    X_df,
+    y_series,
+    test_size=test_size,
+    stratify=y_series,
+    random_state=int(random_state),
+)
+
+model = train_random_forest(
+    X_train,
+    y_train,
+    n_estimators=n_estimators,
+    max_depth=max_depth,
+    criterion=criterion,
+    random_state=int(random_state),
+)
+y_pred, y_proba, metrics = evaluate_random_forest(model, X_test, y_test)
+
+st.subheader("Performance Metrics")
+metrics_df = (
+    pd.DataFrame([metrics])
+    .rename(
+        columns={
+            "accuracy": "Accuracy",
+            "precision": "Precision",
+            "recall": "Recall",
+            "f1_score": "F1 Score",
+            "roc_auc": "ROC AUC",
+        }
+    )
+    .round(3)
+)
+st.dataframe(metrics_df, use_container_width=True)
+
+st.subheader("Confusion Matrix")
+cm_plot = plot_confusion_matrix(
+    y_test, y_pred, labels=[str(cls) for cls in model.classes_]
+)
+st.pyplot(cm_plot)
+
+st.subheader("Feature Importance")
+fi_plot = plot_feature_importance(X_df.columns.tolist(), model.feature_importances_)
+st.pyplot(fi_plot)
+
+if y_proba is not None:
+    st.subheader("ROC Curve")
+    roc_plot = plot_roc_curve(y_test, y_proba)
+    st.pyplot(roc_plot)

--- a/utils/data_helpers.py
+++ b/utils/data_helpers.py
@@ -1,6 +1,6 @@
 # utils/data_helpers.py
 
-from sklearn.datasets import make_regression
+from sklearn.datasets import make_classification, make_regression
 import pandas as pd
 
 def generate_sample_regression(n_samples=100, n_features=1, noise=0.0, random_state=None):
@@ -27,4 +27,50 @@ def generate_sample_regression(n_samples=100, n_features=1, noise=0.0, random_st
     X_df = pd.DataFrame(X, columns=[f'feature_{i+1}' for i in range(n_features)])
     y_series = pd.Series(y, name='target')
     
+    return X_df, y_series
+
+
+def generate_sample_classification(
+    n_samples=200,
+    n_features=5,
+    n_informative=3,
+    n_redundant=0,
+    class_sep=1.0,
+    flip_y=0.01,
+    random_state=None,
+):
+    """
+    Generate a sample classification dataset.
+
+    Parameters:
+        n_samples (int): Number of data points.
+        n_features (int): Total number of features.
+        n_informative (int): Number of informative features.
+        n_redundant (int): Number of redundant features.
+        class_sep (float): Separation between classes.
+        flip_y (float): Fraction of labels to randomly flip.
+        random_state (int or None): Random seed for reproducibility.
+
+    Returns:
+        X (pd.DataFrame): Feature dataframe of shape (n_samples, n_features)
+        y (pd.Series): Target variable of shape (n_samples,)
+    """
+    informative = min(n_informative, n_features)
+    redundant = min(n_redundant, max(n_features - informative, 0))
+    repeated = max(n_features - informative - redundant, 0)
+
+    X, y = make_classification(
+        n_samples=n_samples,
+        n_features=n_features,
+        n_informative=informative,
+        n_redundant=redundant,
+        n_repeated=repeated,
+        n_classes=2,
+        class_sep=class_sep,
+        flip_y=flip_y,
+        random_state=random_state,
+    )
+    X_df = pd.DataFrame(X, columns=[f"feature_{i+1}" for i in range(n_features)])
+    y_series = pd.Series(y, name="target")
+
     return X_df, y_series

--- a/utils/plot_helpers.py
+++ b/utils/plot_helpers.py
@@ -1,6 +1,7 @@
 import matplotlib.pyplot as plt
+import numpy as np
 import seaborn as sns
-from sklearn.metrics import confusion_matrix, roc_curve, auc
+from sklearn.metrics import auc, confusion_matrix, roc_curve
 
 def plot_regression_line(X, y, model):
     plt.figure()
@@ -25,4 +26,20 @@ def plot_roc_curve(y_true, y_scores):
     plt.plot(fpr, tpr, label=f"AUC = {roc_auc:.2f}")
     plt.plot([0, 1], [0, 1], linestyle="--")
     plt.legend()
+    return plt
+
+
+def plot_feature_importance(feature_names, importances):
+    indices = np.argsort(importances)
+    plt.figure(figsize=(8, 5))
+    sns.barplot(
+        x=importances[indices],
+        y=np.array(feature_names)[indices],
+        orient="h",
+        palette="viridis",
+    )
+    plt.xlabel("Importance")
+    plt.ylabel("Features")
+    plt.title("Random Forest Feature Importance")
+    plt.tight_layout()
     return plt


### PR DESCRIPTION
## Summary
- add random forest training and evaluation helpers
- extend dataset and plotting utilities for classification workflows
- build a Streamlit page to explore metrics, confusion matrix, ROC curve, and feature importances

## Testing
- python3 - <<'PY'
from models.random_forest import train_random_forest, evaluate_random_forest
from utils.data_helpers import generate_sample_classification
from sklearn.model_selection import train_test_split

X, y = generate_sample_classification(n_samples=300, n_features=6, n_informative=4, n_redundant=1, random_state=42)
X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.25, stratify=y, random_state=42)
model = train_random_forest(X_train, y_train, n_estimators=100, max_depth=None, criterion='gini', random_state=42)
y_pred, y_proba, metrics = evaluate_random_forest(model, X_test, y_test)
print('Metrics:', metrics)
print('Proba available:', y_proba is not None)
PY

Closes #58.